### PR TITLE
[Feature/#13] : 화면 분기처리 및 api 연동 구현

### DIFF
--- a/app/src/main/java/com/gdg/crowdzero_android/di/DataSourceModule.kt
+++ b/app/src/main/java/com/gdg/crowdzero_android/di/DataSourceModule.kt
@@ -1,6 +1,8 @@
 package com.gdg.crowdzero_android.di
 
+import com.gdg.data.datasource.CrowdZeroDataSource
 import com.gdg.data.datasource.ExampleDataSource
+import com.gdg.data.datasourceimpl.CrowdZeroDataSourceImpl
 import com.gdg.data.datasourceimpl.ExampleDataSourceImpl
 import dagger.Binds
 import dagger.Module
@@ -15,4 +17,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindExampleDataSource(exampleDataSourceImpl: ExampleDataSourceImpl): ExampleDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindCrowdZeroDataSource(crowdZeroDataSourceImpl: CrowdZeroDataSourceImpl): CrowdZeroDataSource
 }

--- a/app/src/main/java/com/gdg/crowdzero_android/di/Qualifier.kt
+++ b/app/src/main/java/com/gdg/crowdzero_android/di/Qualifier.kt
@@ -8,4 +8,8 @@ annotation class ExampleRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class CrowdZeroRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class AccessToken

--- a/app/src/main/java/com/gdg/crowdzero_android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/gdg/crowdzero_android/di/RepositoryModule.kt
@@ -1,6 +1,8 @@
 package com.gdg.crowdzero_android.di
 
+import com.gdg.data.repositoryimpl.CrowdZeroRepositoryImpl
 import com.gdg.data.repositoryimpl.ExampleRepositoryImpl
+import com.gdg.domain.repository.CrowdZeroRepository
 import com.gdg.domain.repository.ExampleRepository
 import dagger.Binds
 import dagger.Module
@@ -15,4 +17,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindExampleRepository(exampleRepositoryImpl: ExampleRepositoryImpl): ExampleRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCrowdZeroRepository(crowdZeroRepositoryImpl: CrowdZeroRepositoryImpl): CrowdZeroRepository
 }

--- a/app/src/main/java/com/gdg/crowdzero_android/di/RetrofitModule.kt
+++ b/app/src/main/java/com/gdg/crowdzero_android/di/RetrofitModule.kt
@@ -54,4 +54,13 @@ object RetrofitModule {
         .client(okHttpClient)
         .baseUrl(BASE_URL)
         .build()
+
+    @Singleton
+    @Provides
+    @CrowdZeroRetrofit
+    fun provideCrowdZeroRetrofit(okHttpClient: OkHttpClient): Retrofit = Retrofit.Builder()
+        .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
+        .client(okHttpClient)
+        .baseUrl(BASE_URL)
+        .build()
 }

--- a/app/src/main/java/com/gdg/crowdzero_android/di/ServiceModule.kt
+++ b/app/src/main/java/com/gdg/crowdzero_android/di/ServiceModule.kt
@@ -1,5 +1,6 @@
 package com.gdg.crowdzero_android.di
 
+import com.gdg.data.service.CrowdZeroService
 import com.gdg.data.service.ExampleService
 import dagger.Module
 import dagger.Provides
@@ -17,4 +18,10 @@ object ServiceModule {
     fun provideExampleService(
         @ExampleRetrofit retrofit: Retrofit
     ): ExampleService = retrofit.create(ExampleService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCrowdZeroService(
+        @CrowdZeroRetrofit retrofit: Retrofit
+    ): CrowdZeroService = retrofit.create(CrowdZeroService::class.java)
 }

--- a/app/src/main/java/com/gdg/crowdzero_android/navigation/DetailNavigation.kt
+++ b/app/src/main/java/com/gdg/crowdzero_android/navigation/DetailNavigation.kt
@@ -11,7 +11,7 @@ import com.gdg.feature.detail.DetailRoute
 import kotlinx.serialization.Serializable
 
 fun NavController.navigateDetail(
-    id: Int,
+    id: Long,
     navOptions: NavOptions? = null
 ) {
     navigate(
@@ -34,5 +34,5 @@ fun NavGraphBuilder.detailNavGraph(
 
 @Serializable
 data class Detail(
-    val id: Int
+    val id: Long
 ) : Route

--- a/core/src/main/java/com/gdg/core/designsystem/component/indicator/LoadingIndicator.kt
+++ b/core/src/main/java/com/gdg/core/designsystem/component/indicator/LoadingIndicator.kt
@@ -1,7 +1,6 @@
 package com.gdg.core.designsystem.component.indicator
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -11,8 +10,10 @@ import com.gdg.core.designsystem.theme.CrowdZeroAndroidTheme
 import com.gdg.core.designsystem.theme.CrowdZeroTheme
 
 @Composable
-fun LoadingIndicator() {
-    Box(modifier = Modifier.fillMaxSize()) {
+fun LoadingIndicator(
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier) {
         CircularProgressIndicator(
             modifier = Modifier
                 .align(Alignment.Center),

--- a/core/src/main/java/com/gdg/core/designsystem/component/indicator/LoadingIndicator.kt
+++ b/core/src/main/java/com/gdg/core/designsystem/component/indicator/LoadingIndicator.kt
@@ -1,0 +1,31 @@
+package com.gdg.core.designsystem.component.indicator
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.gdg.core.designsystem.theme.CrowdZeroAndroidTheme
+import com.gdg.core.designsystem.theme.CrowdZeroTheme
+
+@Composable
+fun LoadingIndicator() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(Alignment.Center),
+            color = CrowdZeroTheme.colors.green700,
+            trackColor = CrowdZeroTheme.colors.gray500
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LoadingIndicatorPreview() {
+    CrowdZeroAndroidTheme {
+        LoadingIndicator()
+    }
+}

--- a/core/src/main/java/com/gdg/core/type/CongestionType.kt
+++ b/core/src/main/java/com/gdg/core/type/CongestionType.kt
@@ -3,6 +3,7 @@ package com.gdg.core.type
 import androidx.annotation.DrawableRes
 import androidx.compose.ui.graphics.Color
 import com.gdg.core.R
+import com.gdg.core.designsystem.theme.Gray700
 import com.gdg.core.designsystem.theme.Green600
 import com.gdg.core.designsystem.theme.Orange
 import com.gdg.core.designsystem.theme.Red
@@ -32,5 +33,10 @@ enum class CongestionType(
         color = Red,
         index = 3,
         icon = R.drawable.ic_congestion_red
+    ),
+    UNKNOWN(
+        color = Gray700,
+        index = 4,
+        icon = R.drawable.ic_congestion_gray
     )
 }

--- a/core/src/main/java/com/gdg/core/type/DustConditionType.kt
+++ b/core/src/main/java/com/gdg/core/type/DustConditionType.kt
@@ -3,6 +3,7 @@ package com.gdg.core.type
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color
 import com.gdg.core.R
+import com.gdg.core.designsystem.theme.Gray700
 import com.gdg.core.designsystem.theme.Green600
 import com.gdg.core.designsystem.theme.Orange
 import com.gdg.core.designsystem.theme.Red
@@ -22,5 +23,9 @@ enum class DustConditionType(
     BAD(
         title = R.string.dust_condition_bad,
         color = Red
+    ),
+    UNKNOWN(
+        title = R.string.dust_condition_unknown,
+        color = Gray700
     )
 }

--- a/core/src/main/java/com/gdg/core/type/LocationType.kt
+++ b/core/src/main/java/com/gdg/core/type/LocationType.kt
@@ -5,7 +5,7 @@ import com.gdg.core.R
 import com.naver.maps.geometry.LatLng
 
 enum class LocationType(
-    val id: Int,
+    val id: Long,
     @StringRes val title: Int,
     val latLng: LatLng
 ) {
@@ -36,11 +36,11 @@ enum class LocationType(
     ); // 여의도
 
     companion object {
-        fun extractTitleResource(id: Int): Int {
+        fun extractTitleResource(id: Long): Int {
             return entries.find { it.id == id }?.title ?: GWANGHWAMUN.title
         }
 
-        fun extractLatLng(id: Int): LatLng {
+        fun extractLatLng(id: Long): LatLng {
             return entries.find { it.id == id }?.latLng ?: GWANGHWAMUN.latLng
         }
     }

--- a/core/src/main/res/drawable/ic_congestion_gray.xml
+++ b/core/src/main/res/drawable/ic_congestion_gray.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="90dp"
+    android:height="90dp"
+    android:viewportWidth="90"
+    android:viewportHeight="90">
+  <path
+      android:pathData="M45,90C69.853,90 90,69.853 90,45C90,20.147 69.853,0 45,0C20.147,0 0,20.147 0,45C0,69.853 20.147,90 45,90Z"
+      android:strokeAlpha="0.594703"
+      android:fillColor="#808080"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.594703"/>
+  <path
+      android:pathData="M45,61.694C54.22,61.694 61.694,54.22 61.694,45C61.694,35.78 54.22,28.306 45,28.306C35.781,28.306 28.307,35.78 28.307,45C28.307,54.22 35.781,61.694 45,61.694Z"
+      android:fillColor="#808080"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M45,50.806C48.207,50.806 50.806,48.207 50.806,45C50.806,41.793 48.207,39.194 45,39.194C41.793,39.194 39.193,41.793 39.193,45C39.193,48.207 41.793,50.806 45,50.806Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -31,5 +31,6 @@
     <string name="calender_component_date">%1$s년 %2$s월</string>
     <string name="previous_month">이전 달</string>
     <string name="next_month">다음 달</string>
+    <string name="dust_condition_unknown">모름</string>
 
 </resources>

--- a/data/src/main/java/com/gdg/data/datasource/CrowdZeroDataSource.kt
+++ b/data/src/main/java/com/gdg/data/datasource/CrowdZeroDataSource.kt
@@ -1,8 +1,10 @@
 package com.gdg.data.datasource
 
 import com.gdg.data.dto.BaseResponse
+import com.gdg.data.dto.response.CongestionResponseDto
 import com.gdg.data.dto.response.WeatherResponseDto
 
 interface CrowdZeroDataSource {
     suspend fun getWeather(areaId: Long): BaseResponse<WeatherResponseDto>
+    suspend fun getCongestion(areaId: Long): BaseResponse<CongestionResponseDto>
 }

--- a/data/src/main/java/com/gdg/data/datasource/CrowdZeroDataSource.kt
+++ b/data/src/main/java/com/gdg/data/datasource/CrowdZeroDataSource.kt
@@ -1,0 +1,8 @@
+package com.gdg.data.datasource
+
+import com.gdg.data.dto.BaseResponse
+import com.gdg.data.dto.response.WeatherResponseDto
+
+interface CrowdZeroDataSource {
+    suspend fun getWeather(areaId: Long): BaseResponse<WeatherResponseDto>
+}

--- a/data/src/main/java/com/gdg/data/datasourceimpl/CrowdZeroDataSourceImpl.kt
+++ b/data/src/main/java/com/gdg/data/datasourceimpl/CrowdZeroDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.gdg.data.datasourceimpl
 
 import com.gdg.data.datasource.CrowdZeroDataSource
 import com.gdg.data.dto.BaseResponse
+import com.gdg.data.dto.response.CongestionResponseDto
 import com.gdg.data.dto.response.WeatherResponseDto
 import com.gdg.data.service.CrowdZeroService
 import javax.inject.Inject
@@ -11,5 +12,9 @@ class CrowdZeroDataSourceImpl @Inject constructor(
 ) : CrowdZeroDataSource {
     override suspend fun getWeather(areaId: Long): BaseResponse<WeatherResponseDto> {
         return crowdZeroApiService.getWeather(areaId)
+    }
+
+    override suspend fun getCongestion(areaId: Long): BaseResponse<CongestionResponseDto> {
+        return crowdZeroApiService.getCongestion(areaId)
     }
 }

--- a/data/src/main/java/com/gdg/data/datasourceimpl/CrowdZeroDataSourceImpl.kt
+++ b/data/src/main/java/com/gdg/data/datasourceimpl/CrowdZeroDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.gdg.data.datasourceimpl
+
+import com.gdg.data.datasource.CrowdZeroDataSource
+import com.gdg.data.dto.BaseResponse
+import com.gdg.data.dto.response.WeatherResponseDto
+import com.gdg.data.service.CrowdZeroService
+import javax.inject.Inject
+
+class CrowdZeroDataSourceImpl @Inject constructor(
+    private val crowdZeroApiService: CrowdZeroService
+) : CrowdZeroDataSource {
+    override suspend fun getWeather(areaId: Long): BaseResponse<WeatherResponseDto> {
+        return crowdZeroApiService.getWeather(areaId)
+    }
+}

--- a/data/src/main/java/com/gdg/data/dto/BaseResponse.kt
+++ b/data/src/main/java/com/gdg/data/dto/BaseResponse.kt
@@ -1,0 +1,11 @@
+package com.gdg.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponse<T>(
+    @SerialName("code") val code: Int,
+    @SerialName("message") val message: String,
+    @SerialName("data") val data: T? = null
+)

--- a/data/src/main/java/com/gdg/data/dto/response/CongestionResponseDto.kt
+++ b/data/src/main/java/com/gdg/data/dto/response/CongestionResponseDto.kt
@@ -1,0 +1,14 @@
+package com.gdg.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CongestionResponseDto(
+    val areaId: Int,
+    val areaNm: String,
+    val areaCongestLvl: String,
+    val areaCongestMsg: String,
+    val areaPpltnMin: Int,
+    val areaPpltnMax: Int,
+    val ppltnTime: String
+)

--- a/data/src/main/java/com/gdg/data/dto/response/WeatherResponseDto.kt
+++ b/data/src/main/java/com/gdg/data/dto/response/WeatherResponseDto.kt
@@ -1,0 +1,15 @@
+package com.gdg.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherResponseDto(
+    @SerialName("id") val id: Long,
+    @SerialName("areaNm") val areaNm: String,
+    @SerialName("skyStts") val skyStts: String,
+    @SerialName("temp") val temp: Int,
+    @SerialName("pm25Index") val pm25Index: String,
+    @SerialName("pm10Index") val pm10Index: String,
+    @SerialName("areaId") val areaId: Int
+)

--- a/data/src/main/java/com/gdg/data/mapper/ResponseCongestionDtoMapper.kt
+++ b/data/src/main/java/com/gdg/data/mapper/ResponseCongestionDtoMapper.kt
@@ -4,7 +4,7 @@ import com.gdg.data.dto.response.CongestionResponseDto
 import com.gdg.domain.entity.CongestionEntity
 
 fun CongestionResponseDto.toCongestionEntity() = CongestionEntity(
-    id = areaId,
+    id = areaId.toLong(),
     name = areaNm,
     level = areaCongestLvl,
     message = areaCongestMsg,

--- a/data/src/main/java/com/gdg/data/mapper/ResponseCongestionDtoMapper.kt
+++ b/data/src/main/java/com/gdg/data/mapper/ResponseCongestionDtoMapper.kt
@@ -1,0 +1,14 @@
+package com.gdg.data.mapper
+
+import com.gdg.data.dto.response.CongestionResponseDto
+import com.gdg.domain.entity.CongestionEntity
+
+fun CongestionResponseDto.toCongestionEntity() = CongestionEntity(
+    id = areaId,
+    name = areaNm,
+    level = areaCongestLvl,
+    message = areaCongestMsg,
+    min = areaPpltnMin,
+    max = areaPpltnMax,
+    time = ppltnTime
+)

--- a/data/src/main/java/com/gdg/data/mapper/ResponseWeatherDtoMapper.kt
+++ b/data/src/main/java/com/gdg/data/mapper/ResponseWeatherDtoMapper.kt
@@ -1,0 +1,8 @@
+package com.gdg.data.mapper
+
+import com.gdg.data.dto.response.WeatherResponseDto
+import com.gdg.domain.entity.WeatherEntity
+
+fun WeatherResponseDto.toWeatherEntity() = WeatherEntity(
+    id, areaNm, skyStts, temp, pm25Index, pm10Index
+)

--- a/data/src/main/java/com/gdg/data/repositoryimpl/CrowdZeroRepositoryImpl.kt
+++ b/data/src/main/java/com/gdg/data/repositoryimpl/CrowdZeroRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.gdg.data.repositoryimpl
 
 import com.gdg.data.datasource.CrowdZeroDataSource
+import com.gdg.data.mapper.toCongestionEntity
 import com.gdg.data.mapper.toWeatherEntity
+import com.gdg.domain.entity.CongestionEntity
 import com.gdg.domain.entity.WeatherEntity
 import com.gdg.domain.repository.CrowdZeroRepository
 import javax.inject.Inject
@@ -12,6 +14,13 @@ class CrowdZeroRepositoryImpl @Inject constructor(
     override suspend fun getWeather(areaId: Long): Result<WeatherEntity> {
         return runCatching {
             crowdZeroDataSource.getWeather(areaId).data?.toWeatherEntity()
+                ?: throw Exception("Data is null")
+        }
+    }
+
+    override suspend fun getCongestion(areaId: Long): Result<CongestionEntity> {
+        return runCatching {
+            crowdZeroDataSource.getCongestion(areaId).data?.toCongestionEntity()
                 ?: throw Exception("Data is null")
         }
     }

--- a/data/src/main/java/com/gdg/data/repositoryimpl/CrowdZeroRepositoryImpl.kt
+++ b/data/src/main/java/com/gdg/data/repositoryimpl/CrowdZeroRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.gdg.data.repositoryimpl
+
+import com.gdg.data.datasource.CrowdZeroDataSource
+import com.gdg.data.mapper.toWeatherEntity
+import com.gdg.domain.entity.WeatherEntity
+import com.gdg.domain.repository.CrowdZeroRepository
+import javax.inject.Inject
+
+class CrowdZeroRepositoryImpl @Inject constructor(
+    private val crowdZeroDataSource: CrowdZeroDataSource
+) : CrowdZeroRepository {
+    override suspend fun getWeather(areaId: Long): Result<WeatherEntity?> {
+        return runCatching {
+            crowdZeroDataSource.getWeather(areaId).data?.toWeatherEntity()
+        }
+    }
+
+}

--- a/data/src/main/java/com/gdg/data/repositoryimpl/CrowdZeroRepositoryImpl.kt
+++ b/data/src/main/java/com/gdg/data/repositoryimpl/CrowdZeroRepositoryImpl.kt
@@ -9,9 +9,10 @@ import javax.inject.Inject
 class CrowdZeroRepositoryImpl @Inject constructor(
     private val crowdZeroDataSource: CrowdZeroDataSource
 ) : CrowdZeroRepository {
-    override suspend fun getWeather(areaId: Long): Result<WeatherEntity?> {
+    override suspend fun getWeather(areaId: Long): Result<WeatherEntity> {
         return runCatching {
             crowdZeroDataSource.getWeather(areaId).data?.toWeatherEntity()
+                ?: throw Exception("Data is null")
         }
     }
 

--- a/data/src/main/java/com/gdg/data/service/ApiKeyStorage.kt
+++ b/data/src/main/java/com/gdg/data/service/ApiKeyStorage.kt
@@ -5,4 +5,9 @@ object ApiKeyStorage {
     const val V1 = "v1"
     const val USERS = "users"
     const val PAGE = "page"
+    const val PPLTN = "ppltn"
+    const val WEATHER = "weather"
+    const val AREA_ID = "areaId"
+    const val ACDNT = "acdnt"
+    const val ASSEMBLY = "assembly"
 }

--- a/data/src/main/java/com/gdg/data/service/CrowdZeroService.kt
+++ b/data/src/main/java/com/gdg/data/service/CrowdZeroService.kt
@@ -1,0 +1,16 @@
+package com.gdg.data.service
+
+import com.gdg.data.dto.BaseResponse
+import com.gdg.data.dto.response.WeatherResponseDto
+import com.gdg.data.service.ApiKeyStorage.API
+import com.gdg.data.service.ApiKeyStorage.AREA_ID
+import com.gdg.data.service.ApiKeyStorage.WEATHER
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface CrowdZeroService {
+    @GET("/$API/$WEATHER/{$AREA_ID}")
+    suspend fun getWeather(
+        @Path(AREA_ID) areaId: Long
+    ): BaseResponse<WeatherResponseDto>
+}

--- a/data/src/main/java/com/gdg/data/service/CrowdZeroService.kt
+++ b/data/src/main/java/com/gdg/data/service/CrowdZeroService.kt
@@ -1,9 +1,11 @@
 package com.gdg.data.service
 
 import com.gdg.data.dto.BaseResponse
+import com.gdg.data.dto.response.CongestionResponseDto
 import com.gdg.data.dto.response.WeatherResponseDto
 import com.gdg.data.service.ApiKeyStorage.API
 import com.gdg.data.service.ApiKeyStorage.AREA_ID
+import com.gdg.data.service.ApiKeyStorage.PPLTN
 import com.gdg.data.service.ApiKeyStorage.WEATHER
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -13,4 +15,9 @@ interface CrowdZeroService {
     suspend fun getWeather(
         @Path(AREA_ID) areaId: Long
     ): BaseResponse<WeatherResponseDto>
+
+    @GET("/$API/$PPLTN/{$AREA_ID}")
+    suspend fun getCongestion(
+        @Path(AREA_ID) areaId: Long
+    ): BaseResponse<CongestionResponseDto>
 }

--- a/domain/src/main/java/com/gdg/domain/entity/CongestionEntity.kt
+++ b/domain/src/main/java/com/gdg/domain/entity/CongestionEntity.kt
@@ -1,7 +1,7 @@
 package com.gdg.domain.entity
 
 data class CongestionEntity(
-    val id: Int,
+    val id: Long,
     val name: String,
     val level: String,
     val message: String,

--- a/domain/src/main/java/com/gdg/domain/entity/PlaceEntity.kt
+++ b/domain/src/main/java/com/gdg/domain/entity/PlaceEntity.kt
@@ -1,7 +1,7 @@
 package com.gdg.domain.entity
 
 data class PlaceEntity(
-    val id: Int,
+    val id: Long,
     val name: String, //장소명
     val congestion: String, //인구혼잡도
     val min: Int,//인구 실시간 최소

--- a/domain/src/main/java/com/gdg/domain/entity/WeatherEntity.kt
+++ b/domain/src/main/java/com/gdg/domain/entity/WeatherEntity.kt
@@ -1,11 +1,10 @@
 package com.gdg.domain.entity
 
 data class WeatherEntity(
-    val id: Int,
-    val name: String,
-    val status: String,
-    val temperature: Int,
-    val pm25: String,
-    val pm10: String,
-    val time: String
+    val id: Long,
+    val areaNm: String,
+    val skyStts: String,
+    val temp: Int,
+    val pm25Index: String,
+    val pm10Index: String
 )

--- a/domain/src/main/java/com/gdg/domain/repository/CrowdZeroRepository.kt
+++ b/domain/src/main/java/com/gdg/domain/repository/CrowdZeroRepository.kt
@@ -1,7 +1,9 @@
 package com.gdg.domain.repository
 
+import com.gdg.domain.entity.CongestionEntity
 import com.gdg.domain.entity.WeatherEntity
 
 interface CrowdZeroRepository {
     suspend fun getWeather(areaId: Long): Result<WeatherEntity>
+    suspend fun getCongestion(areaId: Long): Result<CongestionEntity>
 }

--- a/domain/src/main/java/com/gdg/domain/repository/CrowdZeroRepository.kt
+++ b/domain/src/main/java/com/gdg/domain/repository/CrowdZeroRepository.kt
@@ -1,0 +1,7 @@
+package com.gdg.domain.repository
+
+import com.gdg.domain.entity.WeatherEntity
+
+interface CrowdZeroRepository {
+    suspend fun getWeather(areaId: Long): Result<WeatherEntity?>
+}

--- a/domain/src/main/java/com/gdg/domain/repository/CrowdZeroRepository.kt
+++ b/domain/src/main/java/com/gdg/domain/repository/CrowdZeroRepository.kt
@@ -3,5 +3,5 @@ package com.gdg.domain.repository
 import com.gdg.domain.entity.WeatherEntity
 
 interface CrowdZeroRepository {
-    suspend fun getWeather(areaId: Long): Result<WeatherEntity?>
+    suspend fun getWeather(areaId: Long): Result<WeatherEntity>
 }

--- a/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
@@ -1,7 +1,6 @@
 package com.gdg.feature.detail
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -24,14 +22,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
@@ -39,20 +32,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.gdg.core.designsystem.component.bar.CongestionBar
-import com.gdg.core.designsystem.component.chip.FineDustChip
 import com.gdg.core.designsystem.component.indicator.LoadingIndicator
 import com.gdg.core.designsystem.theme.CrowdZeroAndroidTheme
 import com.gdg.core.designsystem.theme.CrowdZeroTheme
 import com.gdg.core.state.UiState
 import com.gdg.core.type.CongestionType
-import com.gdg.core.type.DustConditionType
-import com.gdg.core.type.DustType
 import com.gdg.core.type.LocationType
-import com.gdg.core.util.TimeFormatter
 import com.gdg.domain.entity.CongestionEntity
 import com.gdg.domain.entity.WeatherEntity
 import com.gdg.feature.R
+import com.gdg.feature.detail.component.CongestionItem
+import com.gdg.feature.detail.component.WeatherItem
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraAnimation
 import com.naver.maps.map.CameraPosition
@@ -67,8 +57,9 @@ import com.naver.maps.map.compose.MarkerState
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.overlay.OverlayImage
-import okhttp3.internal.immutableListOf
 import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 
 @Composable
@@ -94,37 +85,42 @@ fun DetailRoute(
     val cameraPositionState = rememberCameraPositionState {
         position = CameraPosition(LocationType.extractLatLng(id), 15.0)
     }
+    val time = detailViewModel.getCurrentTimeISO8601()
     val getWeatherState by detailViewModel.getWeatherState.collectAsStateWithLifecycle()
+    val getCongestionState by detailViewModel.getCongestionState.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
         detailViewModel.getWeather(id)
+        detailViewModel.getCongestion(id)
     }
 
     DetailScreen(
+        id = id,
         paddingValues = paddingValues,
         weatherState = getWeatherState,
-        weatherEntity = detailViewModel.mockWeather,
-        congestionEntity = detailViewModel.mockCongestion,
+        congestionState = getCongestionState,
         mapProperties = mapProperties,
         mapUiSettings = mapUiSettings,
         cameraPositionState = cameraPositionState,
         title = stringResource(LocationType.extractTitleResource(id)),
-        location = LocationType.extractLatLng(id)
+        location = LocationType.extractLatLng(id),
+        time = time
     )
 }
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
 fun DetailScreen(
+    id: Long = 0,
     paddingValues: PaddingValues = PaddingValues(),
     weatherState: UiState<WeatherEntity> = UiState.Empty,
-    weatherEntity: WeatherEntity,
-    congestionEntity: CongestionEntity,
+    congestionState: UiState<CongestionEntity> = UiState.Empty,
     mapProperties: MapProperties = MapProperties(),
     mapUiSettings: MapUiSettings = MapUiSettings(),
     cameraPositionState: CameraPositionState = CameraPositionState(),
     title: String = "",
-    location: LatLng = LatLng(37.574187, 126.976882)
+    location: LatLng = LatLng(37.574187, 126.976882),
+    time: String = ""
 ) {
     val scrollState = rememberScrollState()
 
@@ -176,21 +172,30 @@ fun DetailScreen(
             }
 
             is UiState.Loading -> {
-                LoadingIndicator()
+                LoadingIndicator(
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                )
             }
 
             is UiState.Success -> {
                 WeatherItem(
                     data = weatherState.data,
-                    time = congestionEntity.time
+                    time = time
                 )
             }
 
             is UiState.Failure -> {
                 Timber.e("날씨 api 오류 : ${weatherState.msg}")
                 WeatherItem(
-                    data = weatherEntity,
-                    time = congestionEntity.time
+                    data = WeatherEntity(
+                        id = id,
+                        areaNm = title,
+                        skyStts = "정보 없음",
+                        temp = 0,
+                        pm25Index = "정보 없음",
+                        pm10Index = "정보 없음",
+                    ),
+                    time = time
                 )
             }
         }
@@ -205,11 +210,16 @@ fun DetailScreen(
         ) {
             Marker(
                 state = MarkerState(position = location),
-                icon = when (congestionEntity.level) {
-                    "여유" -> OverlayImage.fromResource(CongestionType.GOOD.icon)
-                    "보통" -> OverlayImage.fromResource(CongestionType.NORMAL.icon)
-                    "약간 혼잡" -> OverlayImage.fromResource(CongestionType.LITTLE_BAD.icon)
-                    else -> OverlayImage.fromResource(CongestionType.BAD.icon)
+                icon = when (congestionState is UiState.Success) {
+                    true -> when (congestionState.data.level) {
+                        "여유" -> OverlayImage.fromResource(CongestionType.GOOD.icon)
+                        "보통" -> OverlayImage.fromResource(CongestionType.NORMAL.icon)
+                        "약간 혼잡" -> OverlayImage.fromResource(CongestionType.LITTLE_BAD.icon)
+                        "혼잡" -> OverlayImage.fromResource(CongestionType.BAD.icon)
+                        else -> OverlayImage.fromResource(CongestionType.UNKNOWN.icon)
+                    }
+
+                    false -> OverlayImage.fromResource(CongestionType.UNKNOWN.icon)
                 },
                 onClick = {
                     val cameraUpdate = CameraUpdate
@@ -220,146 +230,35 @@ fun DetailScreen(
                 }
             )
         }
-        CongestionItem(data = congestionEntity)
-    }
-}
+        when (congestionState) {
+            is UiState.Empty -> Timber.d("혼잡도 api 데이터 없음")
+            is UiState.Loading -> LoadingIndicator(
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
 
-@Composable
-fun WeatherItem(
-    data: WeatherEntity,
-    time: String
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(
-                brush = Brush.horizontalGradient(
-                    colors = immutableListOf(
-                        CrowdZeroTheme.colors.blue100,
-                        CrowdZeroTheme.colors.blue200
-                    ),
-                    startX = 0f,
-                    endX = 500f
-                ),
-                shape = RectangleShape
-            )
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column {
-            Text(
-                text = TimeFormatter().weatherTimeFormat(time),
-                style = CrowdZeroTheme.typography.c3Bold,
-                color = CrowdZeroTheme.colors.white
-            )
-            Row(
-                modifier = Modifier.padding(bottom = 10.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Image(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_detail_marker),
-                    contentDescription = null
-                )
-                Text(
-                    text = stringResource(R.string.detail_weather_seoul, data.areaNm),
-                    style = CrowdZeroTheme.typography.c3Regular,
-                    color = CrowdZeroTheme.colors.white
+            is UiState.Success -> CongestionItem(data = congestionState.data)
+            is UiState.Failure -> {
+                Timber.e("혼잡도 api 오류 : ${congestionState.msg}")
+                CongestionItem(
+                    data = CongestionEntity(
+                        id = id,
+                        name = title,
+                        level = "모름",
+                        message = stringResource(R.string.detail_congestion_failure),
+                        min = 0,
+                        max = 0,
+                        time = time
+                    )
                 )
             }
-            FineDustChip(
-                dust = DustType.FINE,
-                condition = when (data.pm25Index) {
-                    "좋음" -> DustConditionType.GOOD
-                    "보통" -> DustConditionType.NORMAL
-                    "나쁨" -> DustConditionType.BAD
-                    else -> DustConditionType.BAD
-                }
-            )
-            Spacer(modifier = Modifier.height(5.dp))
-            FineDustChip(
-                dust = DustType.ULTRA_FINE,
-                condition = when (data.pm10Index) {
-                    "좋음" -> DustConditionType.GOOD
-                    "보통" -> DustConditionType.NORMAL
-                    "나쁨" -> DustConditionType.BAD
-                    else -> DustConditionType.BAD
-                }
-            )
         }
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            modifier = Modifier.padding(end = 7.dp),
-            text = stringResource(R.string.detail_weather_temperature, data.temp),
-            style = CrowdZeroTheme.typography.h1Regular,
-            color = CrowdZeroTheme.colors.white
-        )
-        Image(
-            modifier = Modifier.size(90.dp),
-            imageVector = when (data.skyStts) {
-                "맑음" -> ImageVector.vectorResource(R.drawable.ic_sunny)
-                "구름많음" -> ImageVector.vectorResource(R.drawable.ic_cloudy)
-                "비" -> ImageVector.vectorResource(R.drawable.ic_rainy)
-                "눈" -> ImageVector.vectorResource(R.drawable.ic_snowy)
-                else -> ImageVector.vectorResource(R.drawable.ic_sunny_cloudy)
-            },
-            contentDescription = null,
-            contentScale = ContentScale.Fit
-        )
     }
-}
-
-@Composable
-fun CongestionItem(
-    data: CongestionEntity
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.detail_header_congestion),
-            style = CrowdZeroTheme.typography.h2Bold,
-            color = CrowdZeroTheme.colors.gray900
-        )
-        Text(
-            modifier = Modifier.padding(top = 6.dp, bottom = 2.dp),
-            text = buildAnnotatedString {
-                withStyle(style = SpanStyle(color = CrowdZeroTheme.colors.gray700)) {
-                    append(stringResource(R.string.detail_sub_header_congestion))
-                }
-                withStyle(style = SpanStyle(color = CrowdZeroTheme.colors.orange)) {
-                    append(stringResource(R.string.detail_congestion_count, data.min, data.max))
-                }
-            },
-            style = CrowdZeroTheme.typography.c1SemiBold
-        )
-        Text(
-            text = data.message,
-            style = CrowdZeroTheme.typography.c2Medium1,
-            color = CrowdZeroTheme.colors.gray600
-        )
-    }
-    Spacer(modifier = Modifier.padding(top = 13.dp))
-    CongestionBar(
-        congestionType = when (data.level) {
-            "여유" -> CongestionType.GOOD
-            "보통" -> CongestionType.NORMAL
-            "약간 혼잡" -> CongestionType.LITTLE_BAD
-            else -> CongestionType.BAD
-        }
-    )
 }
 
 @Preview(showBackground = true)
 @Composable
 fun DetailScreenPreview() {
     CrowdZeroAndroidTheme {
-        val detailViewModel: DetailViewModel = hiltViewModel()
-        DetailScreen(
-            weatherEntity = detailViewModel.mockWeather,
-            congestionEntity = detailViewModel.mockCongestion
-        )
+        DetailScreen()
     }
 }

--- a/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
@@ -74,7 +74,7 @@ import timber.log.Timber
 @Composable
 fun DetailRoute(
     detailViewModel: DetailViewModel = hiltViewModel(),
-    id: Int,
+    id: Long,
     paddingValues: PaddingValues
 ) {
     val mapProperties by remember {

--- a/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
@@ -97,7 +97,7 @@ fun DetailRoute(
     val getWeatherState by detailViewModel.getWeatherState.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
-        detailViewModel.getWeather(id.toLong())
+        detailViewModel.getWeather(id)
     }
 
     DetailScreen(

--- a/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailRoute.kt
@@ -158,7 +158,10 @@ fun DetailScreen(
                 contentDescription = null
             )
         }
-        WeatherItem(data = weatherEntity)
+        WeatherItem(
+            data = weatherEntity,
+            time = congestionEntity.time
+        )
         Spacer(modifier = Modifier.height(11.dp))
         NaverMap(
             modifier = Modifier
@@ -191,7 +194,8 @@ fun DetailScreen(
 
 @Composable
 fun WeatherItem(
-    data: WeatherEntity
+    data: WeatherEntity,
+    time: String
 ) {
     Row(
         modifier = Modifier
@@ -212,7 +216,7 @@ fun WeatherItem(
     ) {
         Column {
             Text(
-                text = TimeFormatter().weatherTimeFormat(data.time),
+                text = TimeFormatter().weatherTimeFormat(time),
                 style = CrowdZeroTheme.typography.c3Bold,
                 color = CrowdZeroTheme.colors.white
             )
@@ -226,14 +230,14 @@ fun WeatherItem(
                     contentDescription = null
                 )
                 Text(
-                    text = stringResource(R.string.detail_weather_seoul, data.name),
+                    text = stringResource(R.string.detail_weather_seoul, data.areaNm),
                     style = CrowdZeroTheme.typography.c3Regular,
                     color = CrowdZeroTheme.colors.white
                 )
             }
             FineDustChip(
                 dust = DustType.FINE,
-                condition = when (data.pm25) {
+                condition = when (data.pm25Index) {
                     "좋음" -> DustConditionType.GOOD
                     "보통" -> DustConditionType.NORMAL
                     "나쁨" -> DustConditionType.BAD
@@ -243,7 +247,7 @@ fun WeatherItem(
             Spacer(modifier = Modifier.height(5.dp))
             FineDustChip(
                 dust = DustType.ULTRA_FINE,
-                condition = when (data.pm10) {
+                condition = when (data.pm10Index) {
                     "좋음" -> DustConditionType.GOOD
                     "보통" -> DustConditionType.NORMAL
                     "나쁨" -> DustConditionType.BAD
@@ -254,13 +258,13 @@ fun WeatherItem(
         Spacer(modifier = Modifier.weight(1f))
         Text(
             modifier = Modifier.padding(end = 7.dp),
-            text = stringResource(R.string.detail_weather_temperature, data.temperature),
+            text = stringResource(R.string.detail_weather_temperature, data.temp),
             style = CrowdZeroTheme.typography.h1Regular,
             color = CrowdZeroTheme.colors.white
         )
         Image(
             modifier = Modifier.size(90.dp),
-            imageVector = when (data.status) {
+            imageVector = when (data.skyStts) {
                 "맑음" -> ImageVector.vectorResource(R.drawable.ic_sunny)
                 "구름많음" -> ImageVector.vectorResource(R.drawable.ic_cloudy)
                 "비" -> ImageVector.vectorResource(R.drawable.ic_rainy)

--- a/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
@@ -20,6 +20,10 @@ class DetailViewModel @Inject constructor(
         MutableStateFlow(UiState.Empty)
     val getWeatherState: StateFlow<UiState<WeatherEntity>> get() = _getWeatherState
 
+    private val _getCongestionState: MutableStateFlow<UiState<CongestionEntity>> =
+        MutableStateFlow(UiState.Empty)
+    val getCongestionState: StateFlow<UiState<CongestionEntity>> get() = _getCongestionState
+
     fun getWeather(areaId: Long) {
         viewModelScope.launch {
             _getWeatherState.emit(UiState.Loading)
@@ -29,6 +33,20 @@ class DetailViewModel @Inject constructor(
                 },
                 onFailure = {
                     _getWeatherState.emit(UiState.Failure(it.message.toString()))
+                }
+            )
+        }
+    }
+
+    fun getCongestion(areaId: Long) {
+        viewModelScope.launch {
+            _getCongestionState.emit(UiState.Loading)
+            crowdZeroRepository.getCongestion(areaId).fold(
+                onSuccess = {
+                    _getCongestionState.emit(UiState.Success(it))
+                },
+                onFailure = {
+                    _getCongestionState.emit(UiState.Failure(it.message.toString()))
                 }
             )
         }

--- a/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
@@ -20,10 +20,6 @@ class DetailViewModel @Inject constructor(
         MutableStateFlow(UiState.Empty)
     val getWeatherState: StateFlow<UiState<WeatherEntity>> get() = _getWeatherState
 
-    private val _getCongestionState: MutableStateFlow<UiState<CongestionEntity>> =
-        MutableStateFlow(UiState.Empty)
-    val getCongestionState: StateFlow<UiState<CongestionEntity>> get() = _getCongestionState
-
     fun getWeather(areaId: Long) {
         viewModelScope.launch {
             _getWeatherState.emit(UiState.Loading)
@@ -33,20 +29,6 @@ class DetailViewModel @Inject constructor(
                 },
                 onFailure = {
                     _getWeatherState.emit(UiState.Failure(it.message.toString()))
-                }
-            )
-        }
-    }
-
-    fun getCongestion(areaId: Long) {
-        viewModelScope.launch {
-            _getCongestionState.emit(UiState.Loading)
-            crowdZeroRepository.getCongestion(areaId).fold(
-                onSuccess = {
-                    _getCongestionState.emit(UiState.Success(it))
-                },
-                onFailure = {
-                    _getCongestionState.emit(UiState.Failure(it.message.toString()))
                 }
             )
         }

--- a/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
@@ -16,9 +16,9 @@ import javax.inject.Inject
 class DetailViewModel @Inject constructor(
     private val crowdZeroRepository: CrowdZeroRepository
 ) : ViewModel() {
-    private val _getWeatherState: MutableStateFlow<UiState<WeatherEntity?>> =
+    private val _getWeatherState: MutableStateFlow<UiState<WeatherEntity>> =
         MutableStateFlow(UiState.Empty)
-    val getWeatherState: StateFlow<UiState<WeatherEntity?>> get() = _getWeatherState
+    val getWeatherState: StateFlow<UiState<WeatherEntity>> get() = _getWeatherState
 
     fun getWeather(areaId: Long) {
         viewModelScope.launch {

--- a/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/DetailViewModel.kt
@@ -1,21 +1,46 @@
 package com.gdg.feature.detail
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gdg.core.state.UiState
 import com.gdg.domain.entity.CongestionEntity
 import com.gdg.domain.entity.WeatherEntity
+import com.gdg.domain.repository.CrowdZeroRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class DetailViewModel @Inject constructor() : ViewModel() {
+class DetailViewModel @Inject constructor(
+    private val crowdZeroRepository: CrowdZeroRepository
+) : ViewModel() {
+    private val _getWeatherState: MutableStateFlow<UiState<WeatherEntity?>> =
+        MutableStateFlow(UiState.Empty)
+    val getWeatherState: StateFlow<UiState<WeatherEntity?>> get() = _getWeatherState
+
+    fun getWeather(areaId: Long) {
+        viewModelScope.launch {
+            _getWeatherState.emit(UiState.Loading)
+            crowdZeroRepository.getWeather(areaId).fold(
+                onSuccess = {
+                    _getWeatherState.emit(UiState.Success(it))
+                },
+                onFailure = {
+                    _getWeatherState.emit(UiState.Failure(it.message.toString()))
+                }
+            )
+        }
+    }
+
     val mockWeather = WeatherEntity(
         id = 1,
-        name = "강남역",
-        status = "구름많음",
-        temperature = -3,
-        pm25 = "좋음",
-        pm10 = "나쁨",
-        time = "2025-02-01T10:00:00"
+        areaNm = "강남역",
+        skyStts = "구름많음",
+        temp = -3,
+        pm25Index = "좋음",
+        pm10Index = "나쁨",
     )
 
     val mockCongestion = CongestionEntity(

--- a/feature/src/main/java/com/gdg/feature/detail/component/CongestionItem.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/component/CongestionItem.kt
@@ -1,0 +1,75 @@
+package com.gdg.feature.detail.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.gdg.core.designsystem.component.bar.CongestionBar
+import com.gdg.core.designsystem.theme.CrowdZeroTheme
+import com.gdg.core.type.CongestionType
+import com.gdg.domain.entity.CongestionEntity
+import com.gdg.feature.R
+
+@Composable
+fun CongestionItem(
+    data: CongestionEntity
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.detail_header_congestion),
+            style = CrowdZeroTheme.typography.h2Bold,
+            color = CrowdZeroTheme.colors.gray900
+        )
+        Text(
+            modifier = Modifier.padding(top = 6.dp, bottom = 2.dp),
+            text = buildAnnotatedString {
+                withStyle(style = SpanStyle(color = CrowdZeroTheme.colors.gray700)) {
+                    append(stringResource(R.string.detail_sub_header_congestion))
+                }
+                if (data.min != data.max) {
+                    withStyle(
+                        style = SpanStyle(
+                            color = when (data.level) {
+                                "여유" -> CrowdZeroTheme.colors.green600
+                                "보통" -> CrowdZeroTheme.colors.yellow
+                                "약간 혼잡" -> CrowdZeroTheme.colors.orange
+                                "혼잡" -> CrowdZeroTheme.colors.red
+                                else -> CrowdZeroTheme.colors.gray700
+                            }
+                        )
+                    ) {
+                        append(stringResource(R.string.detail_congestion_count, data.min, data.max))
+                    }
+                }
+            },
+            style = CrowdZeroTheme.typography.c1SemiBold
+        )
+        Text(
+            text = data.message,
+            style = CrowdZeroTheme.typography.c2Medium1,
+            color = CrowdZeroTheme.colors.gray600
+        )
+    }
+    Spacer(modifier = Modifier.padding(top = 13.dp))
+    CongestionBar(
+        congestionType = when (data.level) {
+            "여유" -> CongestionType.GOOD
+            "보통" -> CongestionType.NORMAL
+            "약간 혼잡" -> CongestionType.LITTLE_BAD
+            "혼잡" -> CongestionType.BAD
+            else -> CongestionType.UNKNOWN
+        }
+    )
+}

--- a/feature/src/main/java/com/gdg/feature/detail/component/CongestionItem.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/component/CongestionItem.kt
@@ -38,19 +38,21 @@ fun CongestionItem(
                 withStyle(style = SpanStyle(color = CrowdZeroTheme.colors.gray700)) {
                     append(stringResource(R.string.detail_sub_header_congestion))
                 }
-                if (data.min != data.max) {
-                    withStyle(
-                        style = SpanStyle(
-                            color = when (data.level) {
-                                "여유" -> CrowdZeroTheme.colors.green600
-                                "보통" -> CrowdZeroTheme.colors.yellow
-                                "약간 혼잡" -> CrowdZeroTheme.colors.orange
-                                "혼잡" -> CrowdZeroTheme.colors.red
-                                else -> CrowdZeroTheme.colors.gray700
-                            }
-                        )
-                    ) {
+                withStyle(
+                    style = SpanStyle(
+                        color = when (data.level) {
+                            "여유" -> CrowdZeroTheme.colors.green600
+                            "보통" -> CrowdZeroTheme.colors.yellow
+                            "약간 혼잡" -> CrowdZeroTheme.colors.orange
+                            "혼잡" -> CrowdZeroTheme.colors.red
+                            else -> CrowdZeroTheme.colors.gray700
+                        }
+                    )
+                ) {
+                    if (data.min != data.max) {
                         append(stringResource(R.string.detail_congestion_count, data.min, data.max))
+                    } else {
+                        append(stringResource(R.string.detail_congestion_count_min, data.min))
                     }
                 }
             },

--- a/feature/src/main/java/com/gdg/feature/detail/component/WeatherItem.kt
+++ b/feature/src/main/java/com/gdg/feature/detail/component/WeatherItem.kt
@@ -1,0 +1,116 @@
+package com.gdg.feature.detail.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import com.gdg.core.designsystem.component.chip.FineDustChip
+import com.gdg.core.designsystem.theme.CrowdZeroTheme
+import com.gdg.core.type.DustConditionType
+import com.gdg.core.type.DustType
+import com.gdg.core.util.TimeFormatter
+import com.gdg.domain.entity.WeatherEntity
+import com.gdg.feature.R
+import okhttp3.internal.immutableListOf
+
+@Composable
+fun WeatherItem(
+    data: WeatherEntity,
+    time: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = immutableListOf(
+                        CrowdZeroTheme.colors.blue100,
+                        CrowdZeroTheme.colors.blue200
+                    ),
+                    startX = 0f,
+                    endX = 500f
+                ),
+                shape = RectangleShape
+            )
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column {
+            Text(
+                text = TimeFormatter().weatherTimeFormat(time),
+                style = CrowdZeroTheme.typography.c3Bold,
+                color = CrowdZeroTheme.colors.white
+            )
+            Row(
+                modifier = Modifier.padding(bottom = 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_detail_marker),
+                    contentDescription = null
+                )
+                Text(
+                    text = stringResource(R.string.detail_weather_seoul, data.areaNm),
+                    style = CrowdZeroTheme.typography.c3Regular,
+                    color = CrowdZeroTheme.colors.white
+                )
+            }
+            FineDustChip(
+                dust = DustType.FINE,
+                condition = when (data.pm25Index) {
+                    "좋음" -> DustConditionType.GOOD
+                    "보통" -> DustConditionType.NORMAL
+                    "나쁨" -> DustConditionType.BAD
+                    else -> DustConditionType.UNKNOWN
+                }
+            )
+            Spacer(modifier = Modifier.height(5.dp))
+            FineDustChip(
+                dust = DustType.ULTRA_FINE,
+                condition = when (data.pm10Index) {
+                    "좋음" -> DustConditionType.GOOD
+                    "보통" -> DustConditionType.NORMAL
+                    "나쁨" -> DustConditionType.BAD
+                    else -> DustConditionType.UNKNOWN
+                }
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            modifier = Modifier.padding(end = 7.dp),
+            text = stringResource(R.string.detail_weather_temperature, data.temp),
+            style = CrowdZeroTheme.typography.h1Regular,
+            color = CrowdZeroTheme.colors.white
+        )
+        Image(
+            modifier = Modifier.size(90.dp),
+            imageVector = when (data.skyStts) {
+                "맑음" -> ImageVector.vectorResource(R.drawable.ic_sunny)
+                "구름많음" -> ImageVector.vectorResource(R.drawable.ic_cloudy)
+                "비" -> ImageVector.vectorResource(R.drawable.ic_rainy)
+                "눈" -> ImageVector.vectorResource(R.drawable.ic_snowy)
+                else -> ImageVector.vectorResource(R.drawable.ic_sunny_cloudy)
+            },
+            contentDescription = null,
+            contentScale = ContentScale.Fit
+        )
+    }
+}

--- a/feature/src/main/java/com/gdg/feature/map/MapRoute.kt
+++ b/feature/src/main/java/com/gdg/feature/map/MapRoute.kt
@@ -210,7 +210,20 @@ fun MapScreen(
                     }
                 }
 
-                is UiState.Failure -> Timber.e("인구 혼잡도 정보 실패")
+                is UiState.Failure -> {
+                    Timber.e("인구 혼잡도 정보 실패")
+                    PlaceInfoCard(
+                        place = PlaceEntity(
+                            id = location.id,
+                            name = stringResource(id = location.title),
+                            congestion = "모름",
+                            min = 0,
+                            max = 0
+                        ),
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                        onButtonClick = onButtonClick
+                    )
+                }
             }
         }
     }

--- a/feature/src/main/java/com/gdg/feature/map/MapRoute.kt
+++ b/feature/src/main/java/com/gdg/feature/map/MapRoute.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun MapRoute(
     mapViewModel: MapViewModel = hiltViewModel(),
-    navigateToDetail: (Int) -> Unit
+    navigateToDetail: (Long) -> Unit
 ) {
     val mapProperties by remember {
         mutableStateOf(
@@ -101,8 +101,8 @@ fun MapScreen(
     cameraPositionState: CameraPositionState = CameraPositionState(),
     locations: List<LocationType>,
     roads: List<RoadEntity>,
-    getPlaceEntity: (Int) -> PlaceEntity?,
-    onButtonClick: (Int) -> Unit = { }
+    getPlaceEntity: (Long) -> PlaceEntity?,
+    onButtonClick: (Long) -> Unit = { }
 ) {
     var selectedLocation by remember { mutableStateOf<LocationType?>(null) }
     var selectedRoad by remember { mutableStateOf<RoadEntity?>(null) }

--- a/feature/src/main/java/com/gdg/feature/map/MapSideEffect.kt
+++ b/feature/src/main/java/com/gdg/feature/map/MapSideEffect.kt
@@ -2,4 +2,5 @@ package com.gdg.feature.map
 
 sealed class MapSideEffect {
     data class NavigateToDetail(val id: Long) : MapSideEffect()
+    data class ShowToast(val message: Int) : MapSideEffect()
 }

--- a/feature/src/main/java/com/gdg/feature/map/MapSideEffect.kt
+++ b/feature/src/main/java/com/gdg/feature/map/MapSideEffect.kt
@@ -1,5 +1,5 @@
 package com.gdg.feature.map
 
 sealed class MapSideEffect {
-    data class NavigateToDetail(val id: Int) : MapSideEffect()
+    data class NavigateToDetail(val id: Long) : MapSideEffect()
 }

--- a/feature/src/main/java/com/gdg/feature/map/MapViewModel.kt
+++ b/feature/src/main/java/com/gdg/feature/map/MapViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gdg.core.state.UiState
 import com.gdg.core.type.LocationType
-import com.gdg.domain.entity.CongestionEntity
 import com.gdg.domain.entity.PlaceEntity
 import com.gdg.domain.entity.RoadEntity
 import com.gdg.domain.repository.CrowdZeroRepository
+import com.gdg.feature.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,9 +22,9 @@ import javax.inject.Inject
 class MapViewModel @Inject constructor(
     private val crowdZeroRepository: CrowdZeroRepository
 ) : ViewModel() {
-    private val _getCongestionState: MutableStateFlow<UiState<CongestionEntity>> =
+    private val _getCongestionState: MutableStateFlow<UiState<PlaceEntity>> =
         MutableStateFlow(UiState.Empty)
-    val getCongestionState: StateFlow<UiState<CongestionEntity>> get() = _getCongestionState
+    val getCongestionState: StateFlow<UiState<PlaceEntity>> get() = _getCongestionState
 
     private val _sideEffects: MutableSharedFlow<MapSideEffect> = MutableSharedFlow()
     val sideEffects: SharedFlow<MapSideEffect> get() = _sideEffects
@@ -34,10 +34,18 @@ class MapViewModel @Inject constructor(
             _getCongestionState.emit(UiState.Loading)
             crowdZeroRepository.getCongestion(areaId).fold(
                 onSuccess = {
-                    _getCongestionState.emit(UiState.Success(it))
+                    val placeEntity = PlaceEntity(
+                        id = it.id,
+                        name = it.name,
+                        congestion = it.level,
+                        min = it.min,
+                        max = it.max
+                    )
+                    _getCongestionState.emit(UiState.Success(placeEntity))
                 },
                 onFailure = {
                     _getCongestionState.emit(UiState.Failure(it.message.toString()))
+                    _sideEffects.emit(MapSideEffect.ShowToast(R.string.server_failure))
                 }
             )
         }

--- a/feature/src/main/java/com/gdg/feature/map/component/PlaceInfoCard.kt
+++ b/feature/src/main/java/com/gdg/feature/map/component/PlaceInfoCard.kt
@@ -106,7 +106,8 @@ fun PlaceInfoCard(
                                 "여유" -> CrowdZeroTheme.colors.green600
                                 "보통" -> CrowdZeroTheme.colors.yellow
                                 "약간 혼잡" -> CrowdZeroTheme.colors.orange
-                                else -> CrowdZeroTheme.colors.red
+                                "혼잡" -> CrowdZeroTheme.colors.red
+                                else -> CrowdZeroTheme.colors.gray700
                             }
                         )
                     ) {

--- a/feature/src/main/java/com/gdg/feature/map/component/PlaceInfoCard.kt
+++ b/feature/src/main/java/com/gdg/feature/map/component/PlaceInfoCard.kt
@@ -40,7 +40,7 @@ import com.gdg.feature.R
 fun PlaceInfoCard(
     place: PlaceEntity?,
     modifier: Modifier = Modifier,
-    onButtonClick: (Int) -> Unit
+    onButtonClick: (Long) -> Unit
 ) {
     if (place == null) return
 

--- a/feature/src/main/java/com/gdg/feature/map/component/PlaceInfoCard.kt
+++ b/feature/src/main/java/com/gdg/feature/map/component/PlaceInfoCard.kt
@@ -120,14 +120,33 @@ fun PlaceInfoCard(
             Text(
                 text = buildAnnotatedString {
                     append(stringResource(R.string.place_info_realtime_population))
-                    withStyle(style = SpanStyle(color = CrowdZeroTheme.colors.green700)) {
-                        append(
-                            stringResource(
-                                R.string.place_info_realtime_population_count,
-                                place.min,
-                                place.max
-                            )
+                    withStyle(
+                        style = SpanStyle(
+                            color = when (place.congestion) {
+                                "여유" -> CrowdZeroTheme.colors.green600
+                                "보통" -> CrowdZeroTheme.colors.yellow
+                                "약간 혼잡" -> CrowdZeroTheme.colors.orange
+                                "혼잡" -> CrowdZeroTheme.colors.red
+                                else -> CrowdZeroTheme.colors.gray700
+                            }
                         )
+                    ) {
+                        if (place.min != place.max) {
+                            append(
+                                stringResource(
+                                    R.string.place_info_realtime_population_count,
+                                    place.min,
+                                    place.max
+                                )
+                            )
+                        } else {
+                            append(
+                                stringResource(
+                                    R.string.place_info_realtime_population_count_min,
+                                    place.min
+                                )
+                            )
+                        }
                     }
                 },
                 style = CrowdZeroTheme.typography.c4SemiBold,

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="detail_weather_seoul">%1$s, 서울</string>
     <string name="detail_weather_temperature">%1$s°</string>
     <string name="detail_congestion_count">%1$s~%2$s명</string>
+    <string name="detail_congestion_failure">실시간 인구 정보를 가져오지 못했어요</string>
+    <string name="detail_congestion_count_min">%1$s명</string>
 
     <!--스플래시 -->
     <string name="splash_title1">혼잡</string>
@@ -25,6 +27,7 @@
     <string name="place_info_congestion">"인구혼잡도 "</string>
     <string name="place_info_realtime_population">"실시간 인구 "</string>
     <string name="place_info_realtime_population_count">%1$s~%2$s명</string>
+    <string name="place_info_realtime_population_count_min">%1$s명</string>
     <string name="place_info_card_buildings">"배경 빌딩 아이콘"</string>
     <string name="map_modal_header">통제</string>
     <string name="map_modal_generated_time">발생시간 %1$s</string>
@@ -43,6 +46,5 @@
     <string name="calendar_people_reporting">%1$s명</string>
     <string name="calender_jurisdiction">관할시</string>
     <string name="calender_no_info">해당 날짜의 집회 정보가 없습니다</string>
-    <string name="detail_congestion_failure">실시간 인구 정보를 가져오지 못했어요</string>
 
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -43,5 +43,6 @@
     <string name="calendar_people_reporting">%1$s명</string>
     <string name="calender_jurisdiction">관할시</string>
     <string name="calender_no_info">해당 날짜의 집회 정보가 없습니다</string>
+    <string name="detail_congestion_failure">실시간 인구 정보를 가져오지 못했어요</string>
 
 </resources>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #13 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 로딩 인디케이터
- 서버 연결 실패 시 화면 처리 
   - PlaceInfoCard 인구혼잡도 '모름', 실시간 인구 '0명' 처리
   - 상세 페이지 미세먼지, 초미세먼지 '모름', 기온 '0도' 처리
   - 상세 페이지 실시간 인구 '0명', 혼잡도 게이지 마커 안뜨도록 처리
- 지도 페이지에서 인구 혼잡도 api 연동
- 상세 페이지에서 인구 혼잡도, 날씨 api 연동

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/7e069e1f-d53b-48d6-99f7-7011480f88ff


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
서버랑 연결 실패했을 때의 타입도 필요할 것 같아서 DustType이랑 CongestionType에 Unknown 타입 추가했습니다. 다 회색으로 처리했어유
다른 분들도 제 코드 참고해서 연동 작업 미리 해주세요!! @nhyeonii @jjwm10625 